### PR TITLE
Make the sorter able to outsource oversized data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 byteorder = "1.3.4"
 flate2 = { version = "1.0", optional = true }
 log = "0.4.11"
+memmap = "0.7.0"
 snap = { version = "1.0.0", optional = true }
 tempfile = "3.1.0"
 zstd = { version = "0.5.1", optional = true }


### PR DESCRIPTION
There was a problem when entries inserted in a sorter were too big and were forcing the sorter to immediately dump the internal buffer to disk even if the number of entries in the buffer was very low; doing that was triggering another process that was merging the chunk files when the count of them was reaching a certain point. The merging step was very fast as it involved a very low amount of entries to merge (26 chunks by default).

@MarinPostma helped me find a great solution to this problem, exporting the entry data to an external file to avoid exhausting the internal in-memory buffer. The only downside of this fix is that it adds [the memmap dependency](https://docs.rs/memmap) to the library. By default, the data is outsourced when it is bigger than 5 percent of the max memory parameter.