### PR TITLE
Correctly write a chunk when then number of entries reach max-memory

### DIFF
--- a/src/sorter.rs
+++ b/src/sorter.rs
@@ -156,7 +156,7 @@ where MF: for<'a> Fn(&[u8], &[Cow<'a, [u8]>]) -> Result<Vec<u8>, U>
         self.entry_bytes += ent.data.len();
         self.entries.push(ent);
 
-        let entries_vec_size = self.entries.capacity() * size_of::<Entry>();
+        let entries_vec_size = self.entries.len() * size_of::<Entry>();
         if self.entry_bytes + entries_vec_size >= self.max_memory {
             self.write_chunk()?;
             if self.chunks.len() > self.max_nb_chunks {


### PR DESCRIPTION
This PR correctly triggers writing the in-memory buffer to disk when the number of entries reached the max-memory limit, the previous code when checking that the capacity of the entries buffer reached the threshold, unfortunately, the capacity was never shrunk and therefore the system was always triggered, at ever insert.

Note that the entries buffer capacity represents the real amount of memory consumed by the sorter, using the length of it is kind of wrong, but the amount of memory represented by the length doesn't outfit the max-memory by far compared to the capacity.

This PR closes #1 that is fixing an imaginary bug.