### PR TITLE
Make the tempfile dependency optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,3 +56,25 @@ jobs:
         with:
           command: clippy
           args: --all-features
+
+  miri:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v1
+
+        - uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            toolchain: nightly
+            override: true
+            components: miri, rust-src
+
+        - uses: actions-rs/cargo@v1
+          with:
+            command: miri
+            args: setup
+
+        - uses: actions-rs/cargo@v1
+          with:
+            command: miri
+            args: test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ bytemuck = { version = "1.7.0", features = ["derive"] }
 byteorder = "1.3.4"
 flate2 = { version = "1.0", optional = true }
 snap = { version = "1.0.0", optional = true }
-tempfile = "3.1.0"
+tempfile = { version = "3.1.0", optional = true }
 zstd = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9"
 
 [features]
-default = ["zlib", "snappy", "zstd"]
+default = ["tempfile", "zlib", "snappy", "zstd"]
 snappy = ["snap"]
 zlib = ["flate2"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,3 +35,9 @@ impl<U> From<io::Error> for Error<U> {
         Error::Io(err)
     }
 }
+
+impl<U> From<Infallible> for Error<U> {
+    fn from(_err: Infallible) -> Error<U> {
+        unreachable!()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,7 @@ pub use self::compression::CompressionType;
 pub use self::error::Error;
 pub use self::merger::{Merger, MergerBuilder, MergerIter};
 pub use self::reader::Reader;
-pub use self::sorter::{Sorter, SorterBuilder};
+#[cfg(feature = "tempfile")]
+pub use self::sorter::TempFileChunk;
+pub use self::sorter::{ChunkCreation, CursorVec, DefaultChunkCreation, Sorter, SorterBuilder};
 pub use self::writer::{Writer, WriterBuilder};


### PR DESCRIPTION
This PR makes the `tempfile` dependency optional and therefore allows miri to run on the `Sorter` struct. Note that miri found an undefined behavior in the Sorter implementation (when the buffer is deallocated).

Fixes #9

---

I don't understand why the miri CI fails, it works correctly on mac os and debian.