### PR TITLE
Reduce the amount of bytes memcpy in the merger

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -190,6 +190,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     #[cfg(all(feature = "zlib", feature = "snappy", feature = "zstd", feature = "lz4"))]
     fn check_all_compressions() {
         use CompressionType::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut writer = Writer::memory();
-//! writer.insert("first-counter", 119_u32.to_ne_bytes());
-//! writer.insert("second-counter", 384_u32.to_ne_bytes());
+//! writer.insert("first-counter", 119_u32.to_ne_bytes())?;
+//! writer.insert("second-counter", 384_u32.to_ne_bytes())?;
 //!
 //! // We create a reader from our writer.
 //! let cursor = writer.into_inner().map(Cursor::new)?;
@@ -39,7 +39,7 @@
 //! use std::convert::TryInto;
 //! use std::io::Cursor;
 //!
-//! use grenad::{MergerBuilder, Reader, Sorter, Writer};
+//! use grenad::{MergerBuilder, Reader, Writer};
 //!
 //! // This merge function:
 //! //  - parses u32s from native-endian bytes,
@@ -66,11 +66,11 @@
 //!
 //! // We insert our key-value pairs in order and
 //! // mix them between our writers.
-//! writera.insert("first-counter", 32_u32.to_ne_bytes());
-//! writera.insert("second-counter", 64_u32.to_ne_bytes());
-//! writerb.insert("first-counter", 23_u32.to_ne_bytes());
-//! writerb.insert("second-counter", 320_u32.to_ne_bytes());
-//! writerc.insert("first-counter", 64_u32.to_ne_bytes());
+//! writera.insert("first-counter", 32_u32.to_ne_bytes())?;
+//! writera.insert("second-counter", 64_u32.to_ne_bytes())?;
+//! writerb.insert("first-counter", 23_u32.to_ne_bytes())?;
+//! writerb.insert("second-counter", 320_u32.to_ne_bytes())?;
+//! writerc.insert("first-counter", 64_u32.to_ne_bytes())?;
 //!
 //! // We create readers from our writers.
 //! let cursora = writera.into_inner().map(Cursor::new)?;
@@ -82,7 +82,7 @@
 //!
 //! // We create a merger that will sum our u32s when necessary,
 //! // and we add our readers to the list of readers to merge.
-//! let mut merger_builder = MergerBuilder::new(wrapping_sum_u32s);
+//! let merger_builder = MergerBuilder::new(wrapping_sum_u32s);
 //! let merger = merger_builder.add(readera).add(readerb).add(readerc).build();
 //!
 //! // We can iterate over the entries in key-order.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
 //! use std::borrow::Cow;
 //! use std::convert::TryInto;
 //!
-//! use grenad::Sorter;
+//! use grenad::{CursorVec, SorterBuilder};
 //!
 //! // This merge function:
 //! //  - parses u32s from native-endian bytes,
@@ -127,7 +127,7 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // We create a sorter that will sum our u32s when necessary.
-//! let mut sorter = Sorter::new(wrapping_sum_u32s);
+//! let mut sorter = SorterBuilder::new(wrapping_sum_u32s).chunk_creator(CursorVec).build();
 //!
 //! // We insert multiple entries with the same key but different values
 //! // in arbitrary order, the sorter will take care of merging them for us.

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
-use std::cmp::{Ordering, Reverse};
-use std::collections::binary_heap::{BinaryHeap, PeekMut};
-use std::{io, mem};
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::io;
+use std::iter::once;
 
 use crate::{Error, Reader, Writer};
 
@@ -43,25 +44,25 @@ impl<R, MF> Extend<Reader<R>> for MergerBuilder<R, MF> {
 
 struct Entry<R> {
     iter: Reader<R>,
-    key: Vec<u8>,
-    value: Vec<u8>,
 }
 
-impl<R: io::Read> Ord for Entry<R> {
+impl<R> Ord for Entry<R> {
     fn cmp(&self, other: &Entry<R>) -> Ordering {
-        self.key.cmp(&other.key)
+        let skey = self.iter.current().map(|(k, _)| k);
+        let okey = other.iter.current().map(|(k, _)| k);
+        skey.cmp(&okey).reverse()
     }
 }
 
-impl<R: io::Read> Eq for Entry<R> {}
+impl<R> Eq for Entry<R> {}
 
-impl<R: io::Read> PartialEq for Entry<R> {
+impl<R> PartialEq for Entry<R> {
     fn eq(&self, other: &Entry<R>) -> bool {
-        self.key == other.key
+        self.cmp(other) == Ordering::Equal
     }
 }
 
-impl<R: io::Read> PartialOrd for Entry<R> {
+impl<R> PartialOrd for Entry<R> {
     fn partial_cmp(&self, other: &Entry<R>) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -87,20 +88,16 @@ impl<R: io::Read, MF> Merger<R, MF> {
     pub fn into_merger_iter(self) -> Result<MergerIter<R, MF>, Error> {
         let mut heap = BinaryHeap::new();
         for mut source in self.sources {
-            if let Some((key, value)) = source.next()? {
-                let key = key.to_vec();
-                let value = value.to_vec();
-                heap.push(Reverse(Entry { iter: source, key, value }));
+            if source.next()?.is_some() {
+                heap.push(Entry { iter: source });
             }
         }
 
         Ok(MergerIter {
             merge: self.merge,
             heap,
-            cur_key: Vec::new(),
-            cur_vals: Vec::new(),
-            merged_val: Vec::new(),
-            pending: false,
+            current_key: Vec::new(),
+            merged_value: Vec::new(),
         })
     }
 }
@@ -123,11 +120,9 @@ where
 /// An iterator that yield the merged entries in key-order.
 pub struct MergerIter<R, MF> {
     merge: MF,
-    heap: BinaryHeap<Reverse<Entry<R>>>,
-    cur_key: Vec<u8>,
-    cur_vals: Vec<Cow<'static, [u8]>>,
-    merged_val: Vec<u8>,
-    pending: bool,
+    heap: BinaryHeap<Entry<R>>,
+    current_key: Vec<u8>,
+    merged_value: Vec<u8>,
 }
 
 impl<R, MF, U> MergerIter<R, MF>
@@ -137,49 +132,54 @@ where
 {
     /// Yield the entries in key-order where values have been merged when needed.
     pub fn next(&mut self) -> Result<Option<(&[u8], &[u8])>, Error<U>> {
-        self.cur_key.clear();
-        self.cur_vals.clear();
+        let first_entry = match self.heap.pop() {
+            Some(entry) => entry,
+            None => return Ok(None),
+        };
 
-        while let Some(mut entry) = self.heap.peek_mut() {
-            if self.cur_key.is_empty() {
-                self.cur_key.extend_from_slice(&entry.0.key);
-                self.cur_vals.clear();
-                self.pending = true;
-            }
+        let (first_key, first_value) = match first_entry.iter.current() {
+            Some((key, value)) => (key, value),
+            None => return Ok(None),
+        };
 
-            if self.cur_key == entry.0.key {
-                self.cur_vals.push(Cow::Owned(mem::take(&mut entry.0.value)));
-                // Replace the key/value buffers by empty ones, empty Vecs don't
-                // allocate, this way we reuse the previously allocated memory.
-                let mut key_buffer = mem::take(&mut entry.0.key);
-                let mut value_buffer = mem::take(&mut entry.0.value);
-                match entry.0.iter.next().map_err(Error::convert_merge_error)? {
-                    Some((key, value)) => {
-                        key_buffer.clear();
-                        value_buffer.clear();
-                        key_buffer.extend_from_slice(key);
-                        value_buffer.extend_from_slice(value);
-                        entry.0.key = key_buffer;
-                        entry.0.value = value_buffer;
+        let mut other_entries = Vec::new();
+        while let Some(entry) = self.heap.peek() {
+            if let Some((key, _value)) = entry.iter.current() {
+                if first_key == key {
+                    if let Some(entry) = self.heap.pop() {
+                        other_entries.push(entry);
                     }
-                    None => {
-                        PeekMut::pop(entry);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let other_values = other_entries.iter().filter_map(|e| e.iter.current().map(|(_k, v)| v));
+        let values: Vec<_> = once(first_value).chain(other_values).map(Cow::Borrowed).collect();
+
+        match (self.merge)(&first_key, &values) {
+            Ok(value) => {
+                self.current_key.clear();
+                self.current_key.extend_from_slice(first_key);
+                match value {
+                    Cow::Owned(value) => self.merged_value = value,
+                    Cow::Borrowed(value) => {
+                        self.merged_value.clear();
+                        self.merged_value.extend_from_slice(value);
                     }
                 }
-            } else {
-                break;
+            }
+            Err(e) => return Err(Error::Merge(e)),
+        }
+
+        // Don't forget to put the entries back into the heap.
+        for mut entry in once(first_entry).chain(other_entries) {
+            if entry.iter.next().map_err(Error::convert_merge_error)?.is_some() {
+                self.heap.push(entry);
             }
         }
 
-        if self.pending {
-            match (self.merge)(&self.cur_key, &self.cur_vals) {
-                Ok(value) => self.merged_val = value.into_owned(),
-                Err(e) => return Err(Error::Merge(e)),
-            }
-            self.pending = false;
-            Ok(Some((&self.cur_key, &self.merged_val)))
-        } else {
-            Ok(None)
-        }
+        Ok(Some((&self.current_key, &self.merged_value)))
     }
 }


### PR DESCRIPTION
This PR highly reduces the amount of `memcpy` when merging multiple `Reader`s by only using references from inside the decompressed block bytes inside the `Reader`. To do that we have introduced a new `Reader::current` method that returns the key-value pair that is currently pointed and that have been returned by the previous call to `Reader::next`, `None` if it has been called already.

The only time we copy memory is when we copy the key that is currently being merged and when the merged value is returned from the merge function in a `Cow::Borrowed` which means that it is borrowed from one of the arguments, it is therefore mandatory to copy it in a `Vec<u8>` inside of the `Merger` struct.

We removed all of the `memcpy` of the values that we want to merge, instead of storing them in a `Vec` of `Cow<'static, [u8]>` and therefore always calling `value.to_vec()` and storing them in a `Cow::Owned`. We now always store the values in a `Cow::Borrowed` avoiding the `to_vec` call.

I am not sure to understand why, but the miri CI passes now, strange but good 🤪