### PR TITLE
Introduce the leveled index block footer along with a FormatV2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,13 @@ tempfile = { version = "3.1.0", optional = true }
 zstd = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
 quickcheck = "0.9"
 rand = "0.8.4"
+
+[[bench]]
+name = "index-levels"
+harness = false
 
 [features]
 default = ["tempfile", "snappy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ license = "MIT"
 bytemuck = { version = "1.7.0", features = ["derive"] }
 byteorder = "1.3.4"
 flate2 = { version = "1.0", optional = true }
-lz4_flex = { version = "0.8.2", optional = true }
-snap = { version = "1.0.0", optional = true }
-tempfile = { version = "3.1.0", optional = true }
-zstd = { version = "0.5.1", optional = true }
+lz4_flex = { version = "0.9.2", optional = true }
+snap = { version = "1.0.5", optional = true }
+tempfile = { version = "3.2.0", optional = true }
+zstd = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ zstd = { version = "0.5.1", optional = true }
 criterion = { version = "0.3", features = ["html_reports"] }
 quickcheck = "0.9"
 rand = "0.8.4"
+grenad-0-4 = { version = "0.4.1", package = "grenad" }
 
 [[bench]]
 name = "index-levels"

--- a/benches/index-levels.rs
+++ b/benches/index-levels.rs
@@ -1,0 +1,49 @@
+use std::io::Cursor;
+use std::iter;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use grenad::{CompressionType, Reader, Writer};
+
+const NUMBER_OF_ENTRIES: u64 = 1_000_000;
+
+fn index_levels(bytes: &[u8]) {
+    let reader = Reader::new(Cursor::new(bytes)).unwrap();
+    let mut cursor = reader.into_cursor().unwrap();
+
+    cursor.move_on_last().unwrap().unwrap();
+    cursor.move_on_first().unwrap().unwrap();
+    cursor.move_on_last().unwrap().unwrap();
+
+    for x in (0..NUMBER_OF_ENTRIES).step_by(1_567) {
+        let num = x.to_be_bytes();
+        cursor.move_on_key_greater_than_or_equal_to(&num).unwrap().unwrap();
+    }
+}
+
+fn generate(levels: u8, count: u64) -> Vec<u8> {
+    let mut writer =
+        Writer::builder().compression_type(CompressionType::Snappy).index_levels(levels).memory();
+    let value: Vec<u8> = iter::repeat(546738_u32.to_be_bytes()).take(30).flatten().collect();
+
+    for x in 0..count {
+        writer.insert(x.to_be_bytes(), &value).unwrap();
+    }
+
+    writer.into_inner().unwrap()
+}
+
+fn bench_index_levels(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Index Levels");
+    for level in [0, 1, 2, 3, 4, 5].iter() {
+        let vec = generate(*level, NUMBER_OF_ENTRIES);
+        let bytes = vec.as_slice();
+
+        group.bench_with_input(BenchmarkId::new("level", level), bytes, |b, bytes| {
+            b.iter(|| index_levels(bytes))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_index_levels);
+criterion_main!(benches);

--- a/qc_loop.sh
+++ b/qc_loop.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+export RUST_BACKTRACE=1
+
+while true
+do
+    cargo test qc_ --release -- --nocapture
+    if [[ x$? != x0 ]] ; then
+        exit $?
+    fi
+done

--- a/src/block.rs
+++ b/src/block.rs
@@ -218,9 +218,8 @@ impl<B: Borrow<Block>> BlockCursor<B> {
     /// Moves the cursor on the key lower than or equal to the given key in this block.
     pub fn move_on_key_lower_than_or_equal_to(&mut self, key: &[u8]) -> Option<(&[u8], &[u8])> {
         let offsets = self.block.borrow().index_offsets();
-        let result = offsets.binary_search_by_key(&key, |off| {
-            let (key, _, _) = self.block.borrow().entry_at(*off as usize).unwrap();
-            key
+        let result = offsets.binary_search_by_key(&Some(key), |off| {
+            self.block.borrow().entry_at(*off as usize).map(|(key, _, _)| key)
         });
 
         match result {

--- a/src/block_writer.rs
+++ b/src/block_writer.rs
@@ -46,6 +46,7 @@ impl Default for BlockWriterBuilder {
 /// The key values are appended one after the other in the block, these entries are
 /// followed by an index that indicates the offset of some of the keys. This footer
 /// index stores an offset every `index_key_interval`.
+#[derive(Clone)]
 pub struct BlockWriter {
     /// The buffer in which we store the indexed bytes.
     /// It contains the key, values and the footer index.

--- a/src/block_writer.rs
+++ b/src/block_writer.rs
@@ -151,7 +151,7 @@ impl Deref for BlockBuffer<'_> {
     type Target = BlockWriter;
 
     fn deref(&self) -> &Self::Target {
-        &self.block_builder
+        self.block_builder
     }
 }
 

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -166,7 +166,7 @@ where
             self.tmp_entries.iter().filter_map(|e| e.cursor.current().map(|(_, v)| v));
         let values: Vec<_> = once(first_value).chain(other_values).map(Cow::Borrowed).collect();
 
-        match (self.merge)(&first_key, &values) {
+        match (self.merge)(first_key, &values) {
             Ok(value) => {
                 self.current_key.clear();
                 self.current_key.extend_from_slice(first_key);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -6,8 +6,10 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crate::compression::CompressionType;
 use crate::error::Error;
 
-const METADATA_SIZE: usize = 17;
+const METADATA_V1_SIZE: usize = 17;
+const METADATA_V2_SIZE: usize = 18;
 const MAGIC_V1: u32 = 0x76324D4C;
+const MAGIC_V2: u32 = 0x6723D4C4;
 
 /// The format version of this file.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
@@ -15,14 +17,22 @@ const MAGIC_V1: u32 = 0x76324D4C;
 pub enum FileVersion {
     /// The first format version.
     FormatV1 = 0,
+    /// The second format version which brings a leveled index footer.
+    FormatV2 = 1,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Metadata {
+    /// The version used to encode this grenad file.
     pub file_version: FileVersion,
+    /// The offset at which the index footer starts in this file.
     pub index_block_offset: u64,
+    /// The compression type used to compress the blocks in this file.
     pub compression_type: CompressionType,
+    /// The number of entries present in this file.
     pub entries_count: u64,
+    /// The number of levels/indirections the index footer have to reach the data blocks.
+    pub index_levels: u8,
 }
 
 impl Metadata {
@@ -33,37 +43,84 @@ impl Metadata {
 
         let file_version = match reader.read_u32::<LittleEndian>()? {
             MAGIC_V1 => FileVersion::FormatV1,
+            MAGIC_V2 => FileVersion::FormatV2,
             _ => return Err(Error::InvalidFormatVersion),
         };
 
-        // Then we seek just before the metadata block (metadata + magic).
-        let footer_size = METADATA_SIZE as i64 + magic_size;
-        reader.seek(SeekFrom::End(-footer_size))?;
+        match file_version {
+            FileVersion::FormatV1 => {
+                // Then we seek just before the metadata block (metadata + magic).
+                let footer_size = METADATA_V1_SIZE as i64 + magic_size;
+                reader.seek(SeekFrom::End(-footer_size))?;
 
-        let index_block_offset = reader.read_u64::<LittleEndian>()?;
-        let compression_type = reader.read_u8()?;
-        let compression_type =
-            CompressionType::from_u8(compression_type).ok_or(Error::InvalidCompressionType)?;
-        let entries_count = reader.read_u64::<LittleEndian>()?;
+                let index_block_offset = reader.read_u64::<LittleEndian>()?;
+                let compression_type = reader.read_u8()?;
+                let compression_type = CompressionType::from_u8(compression_type)
+                    .ok_or(Error::InvalidCompressionType)?;
+                let entries_count = reader.read_u64::<LittleEndian>()?;
 
-        Ok(Metadata { file_version, index_block_offset, compression_type, entries_count })
+                Ok(Metadata {
+                    file_version,
+                    index_block_offset,
+                    compression_type,
+                    entries_count,
+                    index_levels: 0,
+                })
+            }
+            FileVersion::FormatV2 => {
+                // Then we seek just before the metadata block (metadata + magic).
+                let footer_size = METADATA_V2_SIZE as i64 + magic_size;
+                reader.seek(SeekFrom::End(-footer_size))?;
+
+                let index_block_offset = reader.read_u64::<LittleEndian>()?;
+                let compression_type = reader.read_u8()?;
+                let compression_type = CompressionType::from_u8(compression_type)
+                    .ok_or(Error::InvalidCompressionType)?;
+                let entries_count = reader.read_u64::<LittleEndian>()?;
+                let index_levels = reader.read_u8()?;
+
+                Ok(Metadata {
+                    file_version,
+                    index_block_offset,
+                    compression_type,
+                    entries_count,
+                    index_levels,
+                })
+            }
+        }
     }
 
     pub(crate) fn write_into<W: Write>(&self, mut writer: W) -> io::Result<usize> {
-        writer.write_u64::<LittleEndian>(self.index_block_offset)?;
-        writer.write_u8(self.compression_type as u8)?;
-        writer.write_u64::<LittleEndian>(self.entries_count)?;
+        match self.file_version {
+            FileVersion::FormatV1 => {
+                writer.write_u64::<LittleEndian>(self.index_block_offset)?;
+                writer.write_u8(self.compression_type as u8)?;
+                writer.write_u64::<LittleEndian>(self.entries_count)?;
 
-        // Write the magic number at the end of the buffer.
-        writer.write_u32::<LittleEndian>(MAGIC_V1)?;
+                // Write the magic number at the end of the buffer.
+                writer.write_u32::<LittleEndian>(MAGIC_V1)?;
 
-        Ok(METADATA_SIZE + mem::size_of::<u32>())
+                Ok(METADATA_V1_SIZE + mem::size_of::<u32>())
+            }
+            FileVersion::FormatV2 => {
+                writer.write_u64::<LittleEndian>(self.index_block_offset)?;
+                writer.write_u8(self.compression_type as u8)?;
+                writer.write_u64::<LittleEndian>(self.entries_count)?;
+                writer.write_u8(self.index_levels)?;
+
+                // Write the magic number at the end of the buffer.
+                writer.write_u32::<LittleEndian>(MAGIC_V2)?;
+
+                Ok(METADATA_V2_SIZE + mem::size_of::<u32>())
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
+    use std::mem;
 
     use super::*;
 
@@ -74,6 +131,7 @@ mod tests {
             index_block_offset: 0,
             compression_type: CompressionType::None,
             entries_count: 0,
+            index_levels: 0,
         };
 
         let mut cursor = Cursor::new(Vec::new());
@@ -83,5 +141,54 @@ mod tests {
         let new_metadata = Metadata::read_from(&mut cursor).unwrap();
 
         assert_eq!(metadata, new_metadata);
+    }
+
+    #[test]
+    fn check_metadata_v1_size() {
+        let Metadata {
+            file_version: _,
+            index_block_offset,
+            compression_type,
+            entries_count,
+            index_levels: _,
+        } = Metadata {
+            file_version: FileVersion::FormatV1,
+            index_block_offset: 0,
+            compression_type: CompressionType::None,
+            entries_count: 0,
+            index_levels: 0,
+        };
+
+        assert_eq!(
+            METADATA_V1_SIZE,
+            mem::size_of_val(&index_block_offset)
+                + mem::size_of_val(&compression_type)
+                + mem::size_of_val(&entries_count)
+        );
+    }
+
+    #[test]
+    fn check_metadata_v2_size() {
+        let Metadata {
+            file_version: _,
+            index_block_offset,
+            compression_type,
+            entries_count,
+            index_levels,
+        } = Metadata {
+            file_version: FileVersion::FormatV2,
+            index_block_offset: 0,
+            compression_type: CompressionType::None,
+            entries_count: 0,
+            index_levels: 0,
+        };
+
+        assert_eq!(
+            METADATA_V2_SIZE,
+            mem::size_of_val(&index_block_offset)
+                + mem::size_of_val(&compression_type)
+                + mem::size_of_val(&entries_count)
+                + mem::size_of_val(&index_levels)
+        );
     }
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -80,6 +80,11 @@ impl<R> Reader<R> {
         self.metadata.index_block_offset
     }
 
+    /// The number of levels/indirections the index footer have to reach the data blocks.
+    pub(crate) fn index_levels(&self) -> u8 {
+        self.metadata.index_levels
+    }
+
     /// Returns weither this file contains entries or is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -75,6 +75,11 @@ impl<R> Reader<R> {
         self.metadata.entries_count
     }
 
+    /// Returns the offset at which the index footer block starts in this file.
+    pub(crate) fn index_block_offset(&self) -> u64 {
+        self.metadata.index_block_offset
+    }
+
     /// Returns weither this file contains entries or is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0

--- a/src/reader/prefix_iter.rs
+++ b/src/reader/prefix_iter.rs
@@ -65,13 +65,13 @@ impl<R: io::Read + io::Seek> RevPrefixIter<R> {
 }
 
 /// Moves the cursor on the last key that starts with the given prefix or before.
-fn move_on_last_prefix<'c, R: io::Read + io::Seek>(
-    cursor: &'c mut ReaderCursor<R>,
+fn move_on_last_prefix<R: io::Read + io::Seek>(
+    cursor: &mut ReaderCursor<R>,
     prefix: Vec<u8>,
-) -> Result<Option<(&'c [u8], &'c [u8])>, Error> {
+) -> Result<Option<(&[u8], &[u8])>, Error> {
     match advance_key(prefix) {
         Some(next_prefix) => match cursor.move_on_key_lower_than_or_equal_to(&next_prefix)? {
-            Some((k, _)) if k == &next_prefix => cursor.move_on_prev(),
+            Some((k, _)) if k == next_prefix => cursor.move_on_prev(),
             _otherwise => Ok(cursor.current()),
         },
         None => cursor.move_on_last(),

--- a/src/reader/reader_cursor.rs
+++ b/src/reader/reader_cursor.rs
@@ -422,6 +422,17 @@ mod tests {
     use crate::writer::Writer;
 
     #[test]
+    fn simple_empty() {
+        let writer = Writer::builder().index_levels(2).memory();
+        let bytes = writer.into_inner().unwrap();
+        let reader = Reader::new(Cursor::new(bytes.as_slice())).unwrap();
+
+        let mut cursor = reader.into_cursor().unwrap();
+        let result = cursor.move_on_key_greater_than_or_equal_to(&[0, 0, 0, 0]).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
     #[cfg_attr(miri, ignore)]
     fn no_compression() {
         let wb = Writer::builder();

--- a/src/reader/reader_cursor.rs
+++ b/src/reader/reader_cursor.rs
@@ -4,12 +4,12 @@ use std::io::SeekFrom;
 use std::ops::Deref;
 
 use crate::reader::{Block, BlockCursor};
-use crate::{Error, Reader};
+use crate::{CompressionType, Error, Reader};
 
 /// A cursor that can move forward backward and move on a specified key.
 #[derive(Clone)]
 pub struct ReaderCursor<R> {
-    index_block_cursor: BlockCursor<Block>,
+    index_block_cursor: IndexBlockCursor,
     current_cursor: Option<BlockCursor<Block>>,
     reader: Reader<R>,
 }
@@ -41,12 +41,13 @@ impl<R> ReaderCursor<R> {
 
 impl<R: io::Read + io::Seek> ReaderCursor<R> {
     /// Creates a new [`ReaderCursor`] by consumming a [`Reader`].
-    pub(crate) fn new(mut reader: Reader<R>) -> Result<ReaderCursor<R>, Error> {
-        reader.reader.seek(SeekFrom::Start(reader.index_block_offset()))?;
-        let compression_type = reader.compression_type();
-        let index_block = Block::new(&mut reader.reader, compression_type)?;
+    pub(crate) fn new(reader: Reader<R>) -> Result<ReaderCursor<R>, Error> {
         Ok(ReaderCursor {
-            index_block_cursor: index_block.into_cursor(),
+            index_block_cursor: IndexBlockCursor::new(
+                reader.index_block_offset(),
+                reader.compression_type(),
+                reader.index_levels(),
+            ),
             current_cursor: None,
             reader,
         })
@@ -54,7 +55,7 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
 
     /// Returns the block containing the entries that is following the current one.
     pub(crate) fn next_block_from_index(&mut self) -> Result<Option<Block>, Error> {
-        match self.index_block_cursor.move_on_next() {
+        match self.index_block_cursor.move_on_next(&mut self.reader.reader)? {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
@@ -67,7 +68,7 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
 
     /// Returns the block containing the entries that is preceding the current one.
     pub(crate) fn prev_block_from_index(&mut self) -> Result<Option<Block>, Error> {
-        match self.index_block_cursor.move_on_prev() {
+        match self.index_block_cursor.move_on_prev(&mut self.reader.reader)? {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
@@ -80,7 +81,7 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
 
     /// Moves the cursor on the first entry and returns it.
     pub fn move_on_first(&mut self) -> Result<Option<(&[u8], &[u8])>, Error> {
-        match self.index_block_cursor.move_on_first() {
+        match self.index_block_cursor.move_on_first(&mut self.reader.reader)? {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
@@ -100,7 +101,7 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
 
     /// Moves the cursor on the last entry and returns it.
     pub fn move_on_last(&mut self) -> Result<Option<(&[u8], &[u8])>, Error> {
-        match self.index_block_cursor.move_on_last() {
+        match self.index_block_cursor.move_on_last(&mut self.reader.reader)? {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
@@ -180,7 +181,10 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
         // We move on the block which has a key greater than or equal to the key we are
         // searching for as the key stored in the index block is the last key of the block.
         let key = key.as_ref();
-        match self.index_block_cursor.move_on_key_greater_than_or_equal_to(key) {
+        match self
+            .index_block_cursor
+            .move_on_key_greater_than_or_equal_to(key, &mut self.reader.reader)?
+        {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
@@ -211,6 +215,200 @@ impl<R> Deref for ReaderCursor<R> {
 
     fn deref(&self) -> &Self::Target {
         &self.reader
+    }
+}
+
+/// Represent an n-depth index block cursor.
+#[derive(Clone)]
+struct IndexBlockCursor {
+    base_block_offset: u64,
+    compression_type: CompressionType,
+    index_levels: u8,
+    /// Defines the different index block cursor for each depth,
+    /// associated with the offset at which it has been retrieved.
+    /// The length of it must be index_levels + 1 once initialized.
+    inner: Option<Vec<(u64, BlockCursor<Block>)>>,
+}
+
+impl IndexBlockCursor {
+    fn new(
+        base_block_offset: u64,
+        compression_type: CompressionType,
+        index_levels: u8,
+    ) -> IndexBlockCursor {
+        IndexBlockCursor { base_block_offset, compression_type, index_levels, inner: None }
+    }
+
+    fn move_on_first<R: io::Read + io::Seek>(
+        &mut self,
+        reader: R,
+    ) -> Result<Option<(&[u8], &[u8])>, Error> {
+        self.iter_index_blocks(reader, |c| c.move_on_first())
+    }
+
+    fn move_on_last<R: io::Read + io::Seek>(
+        &mut self,
+        reader: R,
+    ) -> Result<Option<(&[u8], &[u8])>, Error> {
+        self.iter_index_blocks(reader, |c| c.move_on_last())
+    }
+
+    fn move_on_next<R: io::Read + io::Seek>(
+        &mut self,
+        reader: R,
+    ) -> Result<Option<(&[u8], &[u8])>, Error> {
+        self.recursive_index_block(reader, |c| c.move_on_next())
+    }
+
+    fn move_on_prev<R: io::Read + io::Seek>(
+        &mut self,
+        reader: R,
+    ) -> Result<Option<(&[u8], &[u8])>, Error> {
+        self.recursive_index_block(reader, |c| c.move_on_prev())
+    }
+
+    fn move_on_key_greater_than_or_equal_to<R: io::Read + io::Seek>(
+        &mut self,
+        key: &[u8],
+        reader: R,
+    ) -> Result<Option<(&[u8], &[u8])>, Error> {
+        self.iter_index_blocks(reader, |c| c.move_on_key_greater_than_or_equal_to(key))
+    }
+
+    fn iter_index_blocks<R, F>(
+        &mut self,
+        mut reader: R,
+        mut mov: F,
+    ) -> Result<Option<(&[u8], &[u8])>, Error>
+    where
+        R: io::Read + io::Seek,
+        F: FnMut(&mut BlockCursor<Block>) -> Option<(&[u8], &[u8])>,
+    {
+        match self.inner.as_mut() {
+            Some(inner) => {
+                let mut jump_to_offset = self.base_block_offset;
+                for (offset, cursor) in inner {
+                    // Only seek and load the Block if it is not already the one that we
+                    // have in memory, we know that by checking the offset of the blocks.
+                    if jump_to_offset != *offset {
+                        reader.seek(SeekFrom::Start(jump_to_offset))?;
+                        *cursor = Block::new(&mut reader, self.compression_type)
+                            .map(Block::into_cursor)?;
+                        *offset = jump_to_offset;
+                    }
+
+                    match (mov)(cursor) {
+                        Some((_, offset_bytes)) => {
+                            let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
+                            jump_to_offset = offset;
+                        }
+                        None => return Ok(None),
+                    }
+                }
+            }
+            None => self.inner = self.initial_index_blocks(reader, mov)?,
+        }
+
+        // We return the position pointed by the last index block level.
+        // The last index blocks exposes the offsets of the data blocks.
+        match self.inner.as_ref().map_or(None, |inner| inner.last()) {
+            Some((_, cursor)) => Ok(cursor.current()),
+            None => Ok(None),
+        }
+    }
+
+    fn recursive_index_block<R, FM>(
+        &mut self,
+        mut reader: R,
+        mut mov: FM,
+    ) -> Result<Option<(&[u8], &[u8])>, Error>
+    where
+        R: io::Read + io::Seek,
+        FM: FnMut(&mut BlockCursor<Block>) -> Option<(&[u8], &[u8])>,
+    {
+        fn recursive<'a, S, FN>(
+            reader: &mut S,
+            compression_type: CompressionType,
+            blocks: &'a mut [(u64, BlockCursor<Block>)],
+            mov: &mut FN,
+        ) -> Result<Option<(&'a [u8], &'a [u8])>, Error>
+        where
+            S: io::Read + io::Seek,
+            FN: FnMut(&mut BlockCursor<Block>) -> Option<(&[u8], &[u8])>,
+        {
+            match blocks.split_last_mut() {
+                Some(((_offset, cursor), head)) => {
+                    match (mov)(cursor) {
+                        Some((_key, _offset)) => Ok(cursor.current()),
+                        None => {
+                            // We reached the end of the current index block, so we ask for the
+                            // parent index block to execute the exact same user function and
+                            // return the offset where is located the block on which we must be
+                            // able to try again.
+                            match recursive(reader, compression_type, head, mov)? {
+                                Some((_, offset_bytes)) => {
+                                    let offset =
+                                        offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
+                                    reader.seek(SeekFrom::Start(offset))?;
+                                    *cursor = Block::new(reader, compression_type)
+                                        .map(Block::into_cursor)?;
+
+                                    // We return the result of the call has is. If it returns None
+                                    // it means we are not able to execute the `mov` function.
+                                    Ok((mov)(cursor))
+                                }
+                                None => Ok(None),
+                            }
+                        }
+                    }
+                }
+                // If we reach this branch it means that the base index block was
+                // not able to execute the `mov` function and that we reached the
+                // end of everything! We must STOP!
+                None => Ok(None),
+            }
+        }
+
+        if self.inner.is_none() {
+            self.inner = self.initial_index_blocks(&mut reader, &mut mov)?;
+        }
+
+        match &mut self.inner {
+            Some(inner) => recursive(&mut reader, self.compression_type, inner, &mut mov),
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the index block cursors by calling the user function to load the blocks.
+    fn initial_index_blocks<R, FM>(
+        &mut self,
+        mut reader: R,
+        mut mov: FM,
+    ) -> Result<Option<Vec<(u64, BlockCursor<Block>)>>, Error>
+    where
+        R: io::Read + io::Seek,
+        FM: FnMut(&mut BlockCursor<Block>) -> Option<(&[u8], &[u8])>,
+    {
+        let depth = self.index_levels as usize + 1;
+        let mut inner = Vec::with_capacity(depth);
+
+        let mut jump_to_offset = self.base_block_offset;
+        for _ in 0..depth {
+            reader.seek(SeekFrom::Start(jump_to_offset))?;
+            let mut cursor =
+                Block::new(&mut reader, self.compression_type).map(Block::into_cursor)?;
+
+            match (mov)(&mut cursor) {
+                Some((_key, offset_bytes)) => {
+                    let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
+                    jump_to_offset = offset;
+                    inner.push((jump_to_offset, cursor));
+                }
+                None => return Ok(None),
+            }
+        }
+
+        Ok(Some(inner))
     }
 }
 
@@ -330,6 +528,88 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn easy_move_on_key_lower_than_or_equal() {
         let mut writer = Writer::memory();
+        let mut nums = Vec::new();
+        for x in (10..24000i32).step_by(3) {
+            nums.push(x);
+            let x = x.to_be_bytes();
+            writer.insert(&x, &x).unwrap();
+        }
+
+        let bytes = writer.into_inner().unwrap();
+        assert_ne!(bytes.len(), 0);
+
+        let reader = Reader::new(Cursor::new(bytes.as_slice())).unwrap();
+        let mut cursor = reader.into_cursor().unwrap();
+        for n in 0..24020i32 {
+            match nums.binary_search(&n) {
+                Ok(i) => {
+                    let n = nums[i];
+                    let (k, _) = cursor
+                        .move_on_key_lower_than_or_equal_to(&n.to_be_bytes())
+                        .unwrap()
+                        .unwrap();
+                    let k = k.try_into().map(i32::from_be_bytes).unwrap();
+                    assert_eq!(k, n);
+                }
+                Err(i) => {
+                    let k = cursor
+                        .move_on_key_lower_than_or_equal_to(&n.to_be_bytes())
+                        .unwrap()
+                        .map(|(k, _)| k.try_into().map(i32::from_be_bytes).unwrap());
+                    let expected = i.checked_sub(1).and_then(|i| nums.get(i)).copied();
+                    assert_eq!(k, expected, "queried value {}", n);
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn easy_move_on_key_greater_than_or_equal_index_levels_2() {
+        let mut wb = Writer::builder();
+        wb.index_levels(2);
+        let mut writer = wb.memory();
+        let mut nums = Vec::new();
+        for x in (10..24000i32).step_by(3) {
+            nums.push(x);
+            let x = x.to_be_bytes();
+            writer.insert(&x, &x).unwrap();
+        }
+
+        let bytes = writer.into_inner().unwrap();
+        assert_ne!(bytes.len(), 0);
+
+        let reader = Reader::new(Cursor::new(bytes.as_slice())).unwrap();
+        let mut cursor = reader.into_cursor().unwrap();
+
+        for n in 0..24020i32 {
+            match nums.binary_search(&n) {
+                Ok(i) => {
+                    let n = nums[i];
+                    let (k, _) = cursor
+                        .move_on_key_greater_than_or_equal_to(&n.to_be_bytes())
+                        .unwrap()
+                        .unwrap();
+                    let k = k.try_into().map(i32::from_be_bytes).unwrap();
+                    assert_eq!(k, n);
+                }
+                Err(i) => {
+                    let k = cursor
+                        .move_on_key_greater_than_or_equal_to(&n.to_be_bytes())
+                        .unwrap()
+                        .map(|(k, _)| k.try_into().map(i32::from_be_bytes).unwrap());
+                    assert_eq!(k, nums.get(i).copied());
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn easy_move_on_key_lower_than_or_equal_index_levels_2() {
+        let mut wb = Writer::builder();
+        wb.index_levels(2);
+        let mut writer = wb.memory();
         let mut nums = Vec::new();
         for x in (10..24000i32).step_by(3) {
             nums.push(x);

--- a/src/reader/reader_cursor.rs
+++ b/src/reader/reader_cursor.rs
@@ -311,7 +311,7 @@ impl IndexBlockCursor {
 
         // We return the position pointed by the last index block level.
         // The last index blocks exposes the offsets of the data blocks.
-        match self.inner.as_ref().map_or(None, |inner| inner.last()) {
+        match self.inner.as_ref().and_then(|inner| inner.last()) {
             Some((_, cursor)) => Ok(cursor.current()),
             None => Ok(None),
         }

--- a/src/reader/reader_cursor.rs
+++ b/src/reader/reader_cursor.rs
@@ -657,6 +657,7 @@ mod tests {
     }
 
     quickcheck! {
+        #[cfg_attr(miri, ignore)]
         fn qc_compare_to_binary_search(nums: Vec<u32>, queries: Vec<u32>) -> bool {
             let mut nums = nums;
             nums.sort_unstable();

--- a/src/reader/reader_cursor.rs
+++ b/src/reader/reader_cursor.rs
@@ -42,8 +42,9 @@ impl<R> ReaderCursor<R> {
 impl<R: io::Read + io::Seek> ReaderCursor<R> {
     /// Creates a new [`ReaderCursor`] by consumming a [`Reader`].
     pub(crate) fn new(mut reader: Reader<R>) -> Result<ReaderCursor<R>, Error> {
-        reader.reader.seek(SeekFrom::Start(reader.metadata.index_block_offset))?;
-        let index_block = Block::new(&mut reader.reader, reader.metadata.compression_type)?;
+        reader.reader.seek(SeekFrom::Start(reader.index_block_offset()))?;
+        let compression_type = reader.compression_type();
+        let index_block = Block::new(&mut reader.reader, compression_type)?;
         Ok(ReaderCursor {
             index_block_cursor: index_block.into_cursor(),
             current_cursor: None,
@@ -57,7 +58,8 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
-                Block::new(&mut self.reader.reader, self.reader.metadata.compression_type).map(Some)
+                let compression_type = self.reader.compression_type();
+                Block::new(&mut self.reader.reader, compression_type).map(Some)
             }
             None => Ok(None),
         }
@@ -69,7 +71,8 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
-                Block::new(&mut self.reader.reader, self.reader.metadata.compression_type).map(Some)
+                let compression_type = self.reader.compression_type();
+                Block::new(&mut self.reader.reader, compression_type).map(Some)
             }
             None => Ok(None),
         }
@@ -81,8 +84,9 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
+                let compression_type = self.reader.compression_type();
                 let current_cursor = self.current_cursor.insert(
-                    Block::new(&mut self.reader.reader, self.reader.metadata.compression_type)
+                    Block::new(&mut self.reader.reader, compression_type)
                         .map(Block::into_cursor)?,
                 );
                 Ok(current_cursor.move_on_first())
@@ -100,8 +104,9 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
+                let compression_type = self.reader.compression_type();
                 let current_cursor = self.current_cursor.insert(
-                    Block::new(&mut self.reader.reader, self.reader.metadata.compression_type)
+                    Block::new(&mut self.reader.reader, compression_type)
                         .map(Block::into_cursor)?,
                 );
                 Ok(current_cursor.move_on_last())
@@ -179,8 +184,9 @@ impl<R: io::Read + io::Seek> ReaderCursor<R> {
             Some((_, offset_bytes)) => {
                 let offset = offset_bytes.try_into().map(u64::from_be_bytes).unwrap();
                 self.reader.reader.seek(SeekFrom::Start(offset))?;
+                let compression_type = self.reader.compression_type();
                 let current_cursor = self.current_cursor.insert(
-                    Block::new(&mut self.reader.reader, self.reader.metadata.compression_type)
+                    Block::new(&mut self.reader.reader, compression_type)
                         .map(Block::into_cursor)?,
                 );
                 Ok(current_cursor.move_on_key_greater_than_or_equal_to(key))

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -41,8 +41,8 @@ impl WriterBuilder {
     }
 
     /// Defines the [`CompressionType`] that will be used to compress the writer blocks.
-    pub fn compression_type(&mut self, ctype: CompressionType) -> &mut Self {
-        self.compression_type = ctype;
+    pub fn compression_type(&mut self, compression_type: CompressionType) -> &mut Self {
+        self.compression_type = compression_type;
         self
     }
 


### PR DESCRIPTION
In this PR we introduce a new way of storing the index block footer. In the previous FormatV1 version of grenad files, the index block footer was a single block containing the list of offsets of the blocks containing the user entries, the keys associated with these blocks were the last key of these user data blocks.

In this new FormatV2 version of the grenad file, it is possible to specify the number of levels/indirection required to reach the actual user data blocks. The index block footer does not necessarily specify where the user data block is located but can rather specify where the next level block is located which will then be used to reach the next index block level and eventually the user data block.

This method of levels/indirections is directly inspired by [the RocksDB partitioned index system](https://github.com/facebook/rocksdb/wiki/Index-Block-Format) and help reduce the amount of time spent decompressing, copying big index block footers when a lot of keys are stored in a grenad file.