### PR TITLE
Avoid copying too much data in memory

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -10,23 +10,31 @@ pub enum CompressionType {
     /// Do not compress the blocks.
     None = 0,
     /// Use the [`snap`] crate to de/compress the blocks.
-    Snappy = 1,
+    ///
+    /// The 0.4.x and previous versions of grenad were using the `snap` crate
+    /// in a wrong way, making the crate slow when compressing using snappy.
+    /// This is the enum variant that defines this way of compression and that
+    /// is exposed for the sake of compatibility.
+    SnappyPre05 = 1,
     /// Use the [`flate2`] crate to de/compress the blocks.
     Zlib = 2,
     /// Use the [`lz4_flex`] crate to de/compress the blocks.
     Lz4 = 3,
     /// Use the [`zstd`] crate to de/compress the blocks.
     Zstd = 4,
+    /// Use the [`snap`] crate to de/compress the blocks.
+    Snappy = 5,
 }
 
 impl CompressionType {
     pub(crate) fn from_u8(value: u8) -> Option<CompressionType> {
         match value {
             0 => Some(CompressionType::None),
-            1 => Some(CompressionType::Snappy),
+            1 => Some(CompressionType::SnappyPre05),
             2 => Some(CompressionType::Zlib),
             3 => Some(CompressionType::Lz4),
             4 => Some(CompressionType::Zstd),
+            5 => Some(CompressionType::Snappy),
             _ => None,
         }
     }
@@ -37,10 +45,11 @@ impl FromStr for CompressionType {
 
     fn from_str(name: &str) -> Result<Self, Self::Err> {
         match name {
-            "snappy" => Ok(CompressionType::Snappy),
+            "snappy-pre-0.5" => Ok(CompressionType::SnappyPre05),
             "zlib" => Ok(CompressionType::Zlib),
             "lz4" => Ok(CompressionType::Lz4),
             "zstd" => Ok(CompressionType::Zstd),
+            "snappy" => Ok(CompressionType::Snappy),
             _ => Err(InvalidCompressionType),
         }
     }
@@ -71,9 +80,10 @@ where
     match typ {
         CompressionType::None => data.read_to_end(out).map(drop),
         CompressionType::Zlib => zlib_decompress(data, out),
-        CompressionType::Snappy => snappy_decompress(data, out),
+        CompressionType::SnappyPre05 => snappy_pre_05_decompress(data, out),
         CompressionType::Lz4 => lz4_decompress(data, out),
         CompressionType::Zstd => zstd_decompress(data, out),
+        CompressionType::Snappy => snappy_decompress(data, out),
     }
 }
 
@@ -81,9 +91,10 @@ pub fn compress(type_: CompressionType, level: u32, data: &[u8]) -> io::Result<C
     match type_ {
         CompressionType::None => Ok(Cow::Borrowed(data)),
         CompressionType::Zlib => zlib_compress(data, level),
-        CompressionType::Snappy => snappy_compress(data, level),
+        CompressionType::SnappyPre05 => snappy_pre_05_compress(data, level),
         CompressionType::Lz4 => lz4_compress(data, level),
         CompressionType::Zstd => zstd_compress(data, level),
+        CompressionType::Snappy => snappy_compress(data, level),
     }
 }
 
@@ -92,8 +103,7 @@ pub fn compress(type_: CompressionType, level: u32, data: &[u8]) -> io::Result<C
 #[cfg(feature = "zlib")]
 fn zlib_decompress<R: io::Read>(data: R, out: &mut Vec<u8>) -> io::Result<()> {
     use std::io::Read;
-    let mut decoder = flate2::read::ZlibDecoder::new(data);
-    decoder.read_to_end(out).map(drop)
+    flate2::read::ZlibDecoder::new(data).read_to_end(out).map(drop)
 }
 
 #[cfg(not(feature = "zlib"))]
@@ -115,15 +125,39 @@ fn zlib_compress(_data: &[u8], _level: u32) -> io::Result<Cow<[u8]>> {
     Err(io::Error::new(io::ErrorKind::Other, "unsupported zlib compression"))
 }
 
-// --------- snappy ---------
+// --------- snappy pre-0.5 ---------
 
 #[cfg(feature = "snappy")]
-fn snappy_decompress<R: io::Read>(mut data: R, out: &mut Vec<u8>) -> io::Result<()> {
+fn snappy_pre_05_decompress<R: io::Read>(mut data: R, out: &mut Vec<u8>) -> io::Result<()> {
     let mut input = Vec::new();
     data.read_to_end(&mut input)?;
     let len = snap::raw::decompress_len(&input)?;
     out.resize(len, 0);
     snap::raw::Decoder::new().decompress(&input, &mut out[..]).map(drop).map_err(Into::into)
+}
+
+#[cfg(not(feature = "snappy"))]
+fn snappy_pre_05_decompress<R: io::Read>(_data: R, _out: &mut Vec<u8>) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, "unsupported snappy decompression"))
+}
+
+#[cfg(feature = "snappy")]
+fn snappy_pre_05_compress(data: &[u8], _level: u32) -> io::Result<Cow<[u8]>> {
+    let mut decoder = snap::raw::Encoder::new();
+    decoder.compress_vec(data).map_err(Into::into).map(Cow::Owned)
+}
+
+#[cfg(not(feature = "snappy"))]
+fn snappy_pre_05_compress(_data: &[u8], _level: u32) -> io::Result<Cow<[u8]>> {
+    Err(io::Error::new(io::ErrorKind::Other, "unsupported snappy compression"))
+}
+
+// --------- snappy ---------
+
+#[cfg(feature = "snappy")]
+fn snappy_decompress<R: io::Read>(mut data: R, out: &mut Vec<u8>) -> io::Result<()> {
+    use io::Read;
+    snap::read::FrameDecoder::new(&mut data).read_to_end(out).map(drop)
 }
 
 #[cfg(not(feature = "snappy"))]
@@ -133,8 +167,10 @@ fn snappy_decompress<R: io::Read>(_data: R, _out: &mut Vec<u8>) -> io::Result<()
 
 #[cfg(feature = "snappy")]
 fn snappy_compress(data: &[u8], _level: u32) -> io::Result<Cow<[u8]>> {
-    let mut decoder = snap::raw::Encoder::new();
-    decoder.compress_vec(data).map_err(Into::into).map(Cow::Owned)
+    use io::Write;
+    let mut encoder = snap::write::FrameEncoder::new(Vec::new());
+    encoder.write_all(data)?;
+    encoder.into_inner().map(Cow::Owned).map_err(|e| e.error().kind().into())
 }
 
 #[cfg(not(feature = "snappy"))]
@@ -170,8 +206,8 @@ fn zstd_compress(_data: &[u8], _level: u32) -> io::Result<Cow<[u8]>> {
 
 #[cfg(feature = "lz4")]
 fn lz4_decompress<R: io::Read>(data: R, out: &mut Vec<u8>) -> io::Result<()> {
-    let mut rdr = lz4_flex::frame::FrameDecoder::new(data);
-    io::copy(&mut rdr, out).map(drop)
+    use io::Read;
+    lz4_flex::frame::FrameDecoder::new(data).read_to_end(out).map(drop)
 }
 
 #[cfg(not(feature = "lz4"))]

--- a/src/reader/reader_cursor.rs
+++ b/src/reader/reader_cursor.rs
@@ -37,6 +37,15 @@ impl<R> ReaderCursor<R> {
     pub fn get_ref(&self) -> &R {
         self.reader.get_ref()
     }
+
+    /// Resets the position of the cursor.
+    ///
+    /// Useful when you want to be able to call `move_on_next` or `move_on_prev` in a loop
+    /// and ensure that it will start from the first or the last value of the cursor.
+    pub fn reset(&mut self) {
+        self.current_cursor = None;
+        self.index_block_cursor.reset();
+    }
 }
 
 impl<R: io::Read + io::Seek> ReaderCursor<R> {
@@ -237,6 +246,10 @@ impl IndexBlockCursor {
         index_levels: u8,
     ) -> IndexBlockCursor {
         IndexBlockCursor { base_block_offset, compression_type, index_levels, inner: None }
+    }
+
+    fn reset(&mut self) {
+        self.inner = None;
     }
 
     fn move_on_first<R: io::Read + io::Seek>(

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -9,8 +9,8 @@ use crate::compression::{compress, CompressionType};
 use crate::count_write::CountWrite;
 use crate::metadata::{FileVersion, Metadata};
 
-pub const DEFAULT_BLOCK_SIZE: usize = 8192;
-pub const MIN_BLOCK_SIZE: usize = 1024;
+const DEFAULT_BLOCK_SIZE: usize = 8192;
+const MIN_BLOCK_SIZE: usize = 1024;
 
 /// A struct that is used to configure a [`Writer`].
 pub struct WriterBuilder {


### PR DESCRIPTION
This PR must wait for #24 to be merged.

This PR introduces a new way of decompressing the block in memory, the previous versions were copying the compressed blocks into a buffer and then calling the `decompress` function with the corresponding slice of bytes. The `decompress` function was returning the decompressed bytes in a `Cow<[u8]>` which was `Borrowed` when the `CompressionType` was `None` and `Owned` (which mean an allocation) when the compression was anything else than `None`.

This PR rewrites the `decompress` method to directly take an `io::Read` in parameter and a mutable reference to the internal buffer, this buffer is then filled directly by the decompression library which itself directly read from the `io::Read` argument. Doing this highly reduces the amount of copy and allocation we do. Keep in mind that this is done for every block we need to read.